### PR TITLE
Add SSO logoutUrl parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ sso:
 | ------- | ------- | ------------- | -------------------------- |
 | enabled | boolean | false         | If true, sso is enabled    |
 | email   | string  | null          | email header to match user |
+| logoutUrl | string | null         | Logout url                 |
 
 elasticApm:
 

--- a/imports/api/users/server/users.js
+++ b/imports/api/users/server/users.js
@@ -507,23 +507,28 @@ Meteor.methods({
     if (!user) {
       return Meteor.absoluteUrl("/");
     }
-    if (!user.services?.oidc) {
-      return Meteor.absoluteUrl("/");
-    }
-    const redirectUrl = Meteor.absoluteUrl("/login");
-    const redirectParameter = Meteor.settings.auth?.oauth2?.logoutRedirectParameter;
-    const baseUrl = Meteor.settings.auth?.oauth2.serverUrl;
-    let logoutUrl = Meteor.settings.auth?.oauth2?.logoutUrl;
-
-    if (!logoutUrl || !baseUrl) {
+    // Oauth enabled
+    if (user.services?.oidc) {
+      const redirectUrl = Meteor.absoluteUrl("/login");
+      const redirectParameter = Meteor.settings.auth?.oauth2?.logoutRedirectParameter;
+      const baseUrl = Meteor.settings.auth?.oauth2.serverUrl;
+      let logoutUrl = Meteor.settings.auth?.oauth2?.logoutUrl;
+      if (!logoutUrl || !baseUrl) {
+        return null;
+      }
+      if (redirectParameter) {
+        if (logoutUrl.indexOf("?") === -1) {
+          logoutUrl = `${logoutUrl}?${redirectParameter}=${redirectUrl}`;
+        }
+      }
+      return `${baseUrl}${logoutUrl}`;
+    // SSO enabled
+    } else if (Boolean(Meteor?.settings?.public?.sso?.enabled) && Meteor?.settings?.public?.sso?.logoutUrl) {
+      return Meteor.settings.public.sso.logoutUrl;
+    // Default logout
+    } else {
       return null;
     }
-    if (redirectParameter) {
-      if (logoutUrl.indexOf("?") === -1) {
-        logoutUrl = `${logoutUrl}?${redirectParameter}=${redirectUrl}`;
-      }
-    }
-    return `${baseUrl}${logoutUrl}`;
   },
 
   "users.oauthEnabled"() {

--- a/settings-development.sample.json
+++ b/settings-development.sample.json
@@ -62,7 +62,8 @@
     "emailVerificationNeeded": false,
     "sso": {
       "enabled": true,
-      "email": "ct-remote-email"
+      "email": "ct-remote-email",
+      "logoutUrl": "/logout"
     },
     "uploadTransport": "ddp",
     "tracking": {


### PR DESCRIPTION
Fixes #112 

Add a simple logoutUrl parameter for SSO (Meteor.settings.public.sso.logoutUrl). (Eg: http://auth.com/logout or /logout)
Update users.getRedirectUrlAfterLogout method to redirect to this logoutUrl if SSO enabled.
