### PR TITLE
Feature/fix upload http auth

### DIFF
--- a/imports/api/attachments/attachments.js
+++ b/imports/api/attachments/attachments.js
@@ -2,7 +2,8 @@ import { Meteor } from "meteor/meteor";
 import { FilesCollection } from "meteor/ostrio:files";
 import {
   checkCanWriteProject,
-  checkCanWriteTask
+  checkCanWriteTask,
+  runAsUser
 } from "/imports/api/permissions/permissions";
 
 export const Attachments = new FilesCollection({
@@ -10,22 +11,24 @@ export const Attachments = new FilesCollection({
   storagePath: Meteor.settings.attachmentsPath || "assets/app/uploads",
   allowClientCode: true, // Disallow remove files from Client
   onBeforeUpload(fileData) {
-    if (fileData.meta?.taskId) {
-      try {
-        checkCanWriteTask(fileData.meta.taskId);
-      } catch (error) {
-        return false;
+    return runAsUser(this.userId, function() {
+      if (fileData.meta?.taskId) {
+        try {
+          checkCanWriteTask(fileData.meta.taskId);
+        } catch (error) {
+          return false;
+        }
       }
-    }
-    if (fileData.meta?.projectId) {
-      try {
-        checkCanWriteProject(fileData.meta.projectId);
-      } catch (error) {
-        return false;
+      if (fileData.meta?.projectId) {
+        try {
+          checkCanWriteProject(fileData.meta.projectId);
+        } catch (error) {
+          return false;
+        }
       }
-    }
+      return true;
+    });
 
-    return true;
   },
   onAfterUpload(fileRef) {
     if (Meteor.isServer) {

--- a/imports/api/attachments/attachments.js
+++ b/imports/api/attachments/attachments.js
@@ -28,7 +28,6 @@ export const Attachments = new FilesCollection({
       }
       return true;
     });
-
   },
   onAfterUpload(fileRef) {
     if (Meteor.isServer) {

--- a/imports/api/permissions/permissions.js
+++ b/imports/api/permissions/permissions.js
@@ -152,10 +152,9 @@ if (Meteor.isServer) {
 }
 
 export const checkLoggedIn = () => {
-  /*
   if (!Meteor.userId()) {
     throw new Meteor.Error("not-authorized");
-  } */
+  }
 };
 
 export const checkAdmin = (scope) => {

--- a/imports/api/permissions/permissions.js
+++ b/imports/api/permissions/permissions.js
@@ -14,6 +14,21 @@ export const PermissionObjects = Object.freeze({
   TASK: "task"
 });
 
+
+// Provide ddp auth
+export const runAsUser = function runAsUser(userId, func) {
+  const { DDPCommon } = Package["ddp-common"];
+  const invocation = new DDPCommon.MethodInvocation({
+    isSimulation: false,
+    userId: userId,
+    setUserId: () => { },
+    unblock: () => { },
+    connection: {},
+    randomSeed: Random.id()
+  });
+  return DDP._CurrentInvocation.withValue(invocation, () => func());
+};
+
 export const Permissions = {
   isAdmin(userId, scope = Roles.GLOBAL_GROUP) {
     if (!userId) {
@@ -137,9 +152,10 @@ if (Meteor.isServer) {
 }
 
 export const checkLoggedIn = () => {
+  /*
   if (!Meteor.userId()) {
     throw new Meteor.Error("not-authorized");
-  }
+  } */
 };
 
 export const checkAdmin = (scope) => {


### PR DESCRIPTION
Wrap Attachments.onBeforeUpload callback in a DDPCommon.MethodInvocation (runAsUser) function to get proper current user context when dealing with http upload transport.

This works with public.uploadTransport set to "ddp" or "http".